### PR TITLE
fix/auth-api-integration

### DIFF
--- a/lib/dashboard/data/datasources/timberland_profile_datasource.dart
+++ b/lib/dashboard/data/datasources/timberland_profile_datasource.dart
@@ -30,7 +30,7 @@ class TimberlandProfileDataSource implements ProfileDataSource {
       }
 
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/${Session().currentUser?.id}/details',
+        '${environmentConfig.apihost}/members/${Session().currentUser?.id}/details',
         data: FormData.fromMap(
           updateProfileParams.toMap()
             ..addEntries(
@@ -92,7 +92,7 @@ class TimberlandProfileDataSource implements ProfileDataSource {
   Future<void> updateEmailRequest(String email, String password) async {
     try {
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/${Session().currentUser?.id}/email',
+        '${environmentConfig.apihost}/members/${Session().currentUser?.id}/email',
         data: json.encode(
           {
             'new_email': email,
@@ -138,7 +138,7 @@ class TimberlandProfileDataSource implements ProfileDataSource {
   Future<void> verifyEmailUpdate(String email, String otp) async {
     try {
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/${Session().currentUser?.id}/email/verify',
+        '${environmentConfig.apihost}/members/${Session().currentUser?.id}/email/verify',
         data: json.encode(
           {
             'new_email': email,
@@ -191,7 +191,7 @@ class TimberlandProfileDataSource implements ProfileDataSource {
   Future<void> resendEmailOtp(String email) async {
     try {
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/${Session().currentUser?.id}/update/email/otp',
+        '${environmentConfig.apihost}/members/${Session().currentUser?.id}/update/email/otp',
         data: json.encode(
           {
             'new_email': email,
@@ -237,7 +237,7 @@ class TimberlandProfileDataSource implements ProfileDataSource {
       String oldPassword, String newPassword) async {
     try {
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/${Session().currentUser?.id}/password',
+        '${environmentConfig.apihost}/members/${Session().currentUser?.id}/password',
         data: json.encode(
           {
             'old_password': oldPassword,

--- a/lib/features/authentication/data/datasources/remote_authenticator.dart
+++ b/lib/features/authentication/data/datasources/remote_authenticator.dart
@@ -33,7 +33,7 @@ class RemoteAuthenticator implements Authenticator {
   Future<User> login(LoginParameter loginParameter) async {
     try {
       final response = await dioClient.post(
-        '${environmentConfig.apihost}/users/login',
+        '${environmentConfig.apihost}/members/login',
         data: {
           'email': loginParameter.email,
           'password': loginParameter.password,
@@ -107,7 +107,7 @@ class RemoteAuthenticator implements Authenticator {
       final Response response;
 
       response = await dioClient.post(
-        '${environmentConfig.apihost}/users/register',
+        '${environmentConfig.apihost}/members/register',
         data: FormData.fromMap(
           registerParameter.toMap()
             ..addEntries(
@@ -167,7 +167,7 @@ class RemoteAuthenticator implements Authenticator {
         },
       );
       final response = await dioClient.post(
-        '${environmentConfig.apihost}/users/verify',
+        '${environmentConfig.apihost}/members/verify',
         data: body,
       );
       log(response.statusCode.toString());
@@ -227,7 +227,7 @@ class RemoteAuthenticator implements Authenticator {
       final Response response;
 
       response = await dioClient.put(
-        '${environmentConfig.apihost}/users/otp',
+        '${environmentConfig.apihost}/members/otp',
         data: {
           'email': email,
         },
@@ -274,7 +274,7 @@ class RemoteAuthenticator implements Authenticator {
       final Response response;
 
       response = await dioClient.post(
-        '${environmentConfig.apihost}/users/forgot',
+        '${environmentConfig.apihost}/members/forgot',
         data: body,
       );
 
@@ -319,7 +319,7 @@ class RemoteAuthenticator implements Authenticator {
         },
       );
       final response = await dioClient.put(
-        '${environmentConfig.apihost}/users/forgot/change',
+        '${environmentConfig.apihost}/members/forgot/change',
         data: body,
       );
       log(response.statusCode.toString());

--- a/lib/features/authentication/data/models/user_model.dart
+++ b/lib/features/authentication/data/models/user_model.dart
@@ -29,7 +29,7 @@ class UserModel extends User {
       },
     );
     return UserModel(
-      id: (map['user_id'] as num?).toString(),
+      id: (map['member_id'] as num?).toString(),
       firstName: map['firstname'] as String,
       middleName:
           map['middlename'] != null ? map['middlename'] as String : null,

--- a/lib/features/authentication/domain/entities/user.dart
+++ b/lib/features/authentication/domain/entities/user.dart
@@ -106,7 +106,7 @@ class User extends Equatable {
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
-      'user_id': int.parse(id),
+      'member_id': int.parse(id),
       'firstname': firstName,
       'middlename': middleName,
       'lastname': lastName,


### PR DESCRIPTION
refactored api integratrion
- all '/users' endpoints are now transferred to '/members'
- 'user_id' field is now called 'member_id'
